### PR TITLE
Use Bootstrap alert colours in debug footer

### DIFF
--- a/block_servermon.php
+++ b/block_servermon.php
@@ -480,13 +480,14 @@ class block_servermon extends block_base {
         ]);
         $html .= $this->debug_row(get_string('debug_session', 'block_servermon'), $sessdetail);
 
-        if ($sess['type'] === 'file') {
-            $html .= '<tr><td colspan="2" class="bsm-debug-warn">'
-                . get_string('debug_session_warn', 'block_servermon')
-                . '</td></tr>';
-        }
-
         $html .= '</table>';
+
+        // File-session warning — Bootstrap alert-warning.
+        if ($sess['type'] === 'file') {
+            $html .= '<div class="alert alert-warning bsm-alert mt-2 mb-2">'
+                . get_string('debug_session_warn', 'block_servermon')
+                . '</div>';
+        }
 
         // Cache stats table.
         $cachestats = $d['cachestats'];
@@ -494,10 +495,10 @@ class block_servermon extends block_base {
             $html .= $this->render_cache_table($cachestats);
         }
 
-        // Observation.
+        // Observation — Bootstrap alert-info.
         if ($d['observation'] !== '') {
-            $html .= '<div class="bsm-debug-obs">'
-                . '<span class="bsm-debug-obs-label">' . get_string('debug_obs', 'block_servermon') . '</span> '
+            $html .= '<div class="alert alert-info bsm-alert mb-0">'
+                . '<strong>' . get_string('debug_obs', 'block_servermon') . ':</strong> '
                 . htmlspecialchars($d['observation'])
                 . '</div>';
         }
@@ -529,8 +530,8 @@ class block_servermon extends block_base {
      * @return string HTML output.
      */
     private function render_cache_table(array $cachestats): string {
-        $html  = '<div class="bsm-debug-cache-title">' . get_string('debug_cache_title', 'block_servermon') . '</div>';
-        $html .= '<table class="bsm-cache-table">';
+        $html  = '<p class="bsm-debug-cache-title">' . get_string('debug_cache_title', 'block_servermon') . '</p>';
+        $html .= '<table class="bsm-cache-table table table-sm table-bordered">';
         $html .= '<thead><tr>'
             . '<th>' . get_string('debug_cache_store',  'block_servermon') . '</th>'
             . '<th class="bsm-num">' . get_string('debug_cache_hits',   'block_servermon') . '</th>'

--- a/styles.css
+++ b/styles.css
@@ -148,59 +148,30 @@
 }
 
 /* --- Debug footer dropdown --- */
-.bsm-debug-warn {
-    font-size: 0.72rem;
-    color: #d68910;
-    font-style: italic;
-    padding: 0.2rem 0.1rem 0.35rem;
+
+/* Scale Bootstrap alerts down to match the block's small type */
+.bsm-alert {
+    font-size: 0.75rem;
+    padding: 0.4rem 0.65rem;
 }
 
 .bsm-debug-cache-title {
     font-size: 0.73rem;
     font-weight: 600;
     opacity: 0.65;
-    margin: 0.8rem 0 0.3rem;
+    margin: 0.75rem 0 0.25rem;
 }
 
 .bsm-cache-table {
-    width: 100%;
-    border-collapse: collapse;
     font-size: 0.75rem;
 }
 
 .bsm-cache-table th {
     font-weight: 600;
-    opacity: 0.55;
-    padding: 0.2rem 0.3rem 0.2rem 0;
-    text-align: left;
-    border-bottom: 1px solid rgba(128, 128, 128, 0.2);
-}
-
-.bsm-cache-table td {
-    padding: 0.25rem 0.3rem 0.25rem 0;
-    border-top: 1px solid rgba(128, 128, 128, 0.08);
-    vertical-align: top;
-}
-
-.bsm-cache-table tr:first-child td {
-    border-top: none;
+    opacity: 0.7;
 }
 
 .bsm-num {
     text-align: right;
     font-variant-numeric: tabular-nums;
-}
-
-.bsm-debug-obs {
-    font-size: 0.72rem;
-    margin-top: 0.6rem;
-    font-style: italic;
-    opacity: 0.75;
-    padding: 0.3rem 0;
-    border-top: 1px solid rgba(128, 128, 128, 0.12);
-}
-
-.bsm-debug-obs-label {
-    font-weight: 600;
-    font-style: normal;
 }


### PR DESCRIPTION
- File-session warning now renders as alert-warning (amber)
- Observation now renders as alert-info (blue) with bold label
- Cache table gains Bootstrap table table-sm table-bordered classes
- Custom bsm-debug-warn / bsm-debug-obs CSS removed; replaced by a single bsm-alert size-tweak rule

https://claude.ai/code/session_01DyMqRnKkU17VMqUUbpiDN4