### PR TITLE
Make print isolation robust (display:none instead of visibility:hidden)

### DIFF
--- a/block_servermon.php
+++ b/block_servermon.php
@@ -1246,26 +1246,40 @@ class block_servermon extends block_base {
     if (!btn) { return; }
     var root = btn.closest('.block-servermon');
     if (!root) { return; }
-    var changed = [];
-    function expand() {
+    var opened = [];
+    var hidden = [];
+    function prepare() {
+        // Expand static detail sections (leave the live process panel as-is).
         var items = root.querySelectorAll('details.bsm-details');
         for (var i = 0; i < items.length; i++) {
             var d = items[i];
             if (d.id && d.id.indexOf('bsm-proc-details') === 0) { continue; }
-            if (!d.open) { d.open = true; changed.push(d); }
+            if (!d.open) { d.open = true; opened.push(d); }
+        }
+        // Collapse everything except the block by hiding siblings up the tree,
+        // so the rest of the dashboard does not print blank pages.
+        var el = root;
+        while (el && el.parentNode && el !== document.body) {
+            var sibs = el.parentNode.children;
+            for (var j = 0; j < sibs.length; j++) {
+                var sib = sibs[j];
+                if (sib !== el && sib.style.display !== 'none') {
+                    hidden.push([sib, sib.style.display]);
+                    sib.style.display = 'none';
+                }
+            }
+            el = el.parentNode;
         }
     }
     function restore() {
-        for (var i = 0; i < changed.length; i++) { changed[i].open = false; }
-        changed = [];
+        for (var i = 0; i < hidden.length; i++) { hidden[i][0].style.display = hidden[i][1]; }
+        hidden = [];
+        for (var k = 0; k < opened.length; k++) { opened[k].open = false; }
+        opened = [];
     }
-    window.addEventListener('beforeprint', expand);
+    window.addEventListener('beforeprint', prepare);
     window.addEventListener('afterprint', restore);
-    btn.addEventListener('click', function(e) {
-        e.preventDefault();
-        expand();
-        window.print();
-    });
+    btn.addEventListener('click', function(e) { e.preventDefault(); window.print(); });
 })();
 JSEOF;
         // phpcs:enable

--- a/styles.css
+++ b/styles.css
@@ -539,20 +539,7 @@
 }
 
 @media print {
-    body * {
-        visibility: hidden;
-    }
-
-    .block-servermon,
-    .block-servermon * {
-        visibility: visible;
-    }
-
     .block-servermon {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
         font-size: 0.9rem;
         -webkit-print-color-adjust: exact;
         print-color-adjust: exact;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_servermon';
-$plugin->version   = 2026061504;
+$plugin->version   = 2026061505;
 $plugin->requires  = 2025041400; // Moodle 5.0 minimum (version 2025041400), PHP 8.2+.
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.8.0';
+$plugin->release   = '1.8.1';


### PR DESCRIPTION
## Summary

Hardens the print isolation introduced in v1.8.0. (Correction: the test PDF turned out to be **3 pages**, not the 55 a tooling estimate suggested — the PDF's own page tree reports `/Count 3`. So this is a robustness improvement, not a critical blank-pages fix.)

## Why

v1.8.0 isolated the block for print with `visibility: hidden` on the rest of the page. That works, but hidden elements **still occupy their space**, so on a tall dashboard the print can stretch across extra (blank) pages. Using `display: none` instead removes the rest of the page from the print flow entirely, so the output is always just the block with no trailing blank pages, independent of how long the dashboard is.

## Change

Pure CSS can't target the block's ancestor chain without knowing Moodle's DOM, so it's done in JS:

- On `beforeprint`: walk up from `.block-servermon` and set `display: none` on every sibling at each ancestor level (saving prior inline values), in addition to expanding the static detail sections.
- On `afterprint`: restore the saved display values and re-collapse the sections.

Works for the button and Ctrl/Cmd-P. The `@media print` stylesheet is trimmed to colour-adjust, the print header, hiding the button/CSV link, and summary styling.

## Notes
- Tier 1 / client-side; no new endpoints or DB changes.
- `php -l` clean, no `!important`, no line-length issues.

Version `1.8.1` (`2026061505`).

https://claude.ai/code/session_015YmQ7o2tPizMps3dnSThzQ