### PR TITLE
Make all toggle bars visually consistent

### DIFF
--- a/block_servermon.php
+++ b/block_servermon.php
@@ -1614,7 +1614,7 @@ JSEOF;
         $body .= $this->render_isolation_verdict($iso['verdict']);
 
         return '<details class="bsm-details">'
-            . '<summary class="bsm-summary bsm-summary-debug">' . $label . '</summary>'
+            . '<summary class="bsm-summary">' . $label . '</summary>'
             . '<div class="bsm-iso-body">' . $body . '</div>'
             . '</details>';
     }
@@ -1868,7 +1868,7 @@ JSEOF;
         }
 
         return '<details class="bsm-details">'
-            . '<summary class="bsm-summary bsm-summary-debug">' . $label . '</summary>'
+            . '<summary class="bsm-summary">' . $label . '</summary>'
             . '<div class="bsm-debug-body">' . $html . '</div>'
             . '</details>';
     }

--- a/styles.css
+++ b/styles.css
@@ -135,7 +135,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.78rem;
+    font-size: 0.82rem;
     font-weight: 600;
     cursor: pointer;
     user-select: none;
@@ -217,11 +217,6 @@ details[open] > .bsm-summary::after {
 }
 
 /* --- Debug footer dropdown --- */
-
-.bsm-summary-debug {
-    font-size: 0.82rem;
-    font-weight: 700;
-}
 
 .bsm-debug-body {
     padding-top: 0.6rem;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_servermon';
-$plugin->version   = 2026061701;
+$plugin->version   = 2026061702;
 $plugin->requires  = 2025041400; // Moodle 5.0 minimum (version 2025041400), PHP 8.2+.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = '1.9.0';


### PR DESCRIPTION
## Summary

Follow-up to #33 (now merged). The toggle bars were not visually uniform: two of the four (**OS users & PHP-FPM pools** and **Moodle debug footer**) carried an extra `.bsm-summary-debug` class that rendered them bolder and larger (700 / 0.82rem) than the **Top processes** and **Server Info** bars (600 / 0.78rem).

## Changes
- Drop the `.bsm-summary-debug` class from the isolation and debug-footer `<summary>` elements so all four bars share the single `.bsm-summary` style.
- Remove the now-unused `.bsm-summary-debug` CSS rule.
- Unify the base `.bsm-summary` font size at `0.82rem` (weight stays 600), so every section bar looks identical.
- Bump version to bust Moodle's cached stylesheet.

## Test plan
- [ ] All four toggle bars render with identical font weight/size and chrome.
- [ ] Expand/collapse and the rotating chevron still work on every bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVGNWRA5itYZ2v3UggEz3W)_